### PR TITLE
버그수정 및 재배포 [230423-2]

### DIFF
--- a/client/src/components/Avatar/CategoryAvatar.tsx
+++ b/client/src/components/Avatar/CategoryAvatar.tsx
@@ -14,9 +14,11 @@ function CategoryAvatar() {
   const navigator = useNavigate();
 
   function categoryClickHandler(name: string) {
-    navigator("/search");
     localStorage.setItem(SEARCH_VALUE, name);
     searchValueVar(name);
+    navigator(
+      `/search?search=${localStorage.getItem(SEARCH_VALUE)}&filter=null`
+    );
   }
 
   return (

--- a/client/src/components/Header/SearchBar.tsx
+++ b/client/src/components/Header/SearchBar.tsx
@@ -13,9 +13,11 @@ function SearchBar() {
   const navigator = useNavigate();
 
   function searchClickHandler() {
-    navigator("/search");
     localStorage.setItem(SEARCH_VALUE, input);
     searchValueVar(input);
+    navigator(
+      `/search?search=${localStorage.getItem(SEARCH_VALUE)}&filter=null`
+    );
   }
 
   return (

--- a/client/src/constant/oAuth.ts
+++ b/client/src/constant/oAuth.ts
@@ -1,10 +1,8 @@
 export const CLIENT_ID = process.env.REACT_APP_JS_SDK_KEY;
 export const ADMIN_KEY = process.env.REACT_APP_ADMIN_KEY;
-export const LOGIN_REDIRECT_URI = "http://localhost:3000/oauth/callback/kakao";
-export const LOGOUT_REDIRECT_URI =
-  "http://localhost:3000/oauth/callback/kakao/logout";
-
-export const BASE_URL = "http://localhost:3000";
+export const BASE_URL = process.env.REACT_APP_CLINET_BASE_URL;
+export const LOGIN_REDIRECT_URI = `${BASE_URL}/oauth/callback/kakao`;
+export const LOGOUT_REDIRECT_URI = `${BASE_URL}/oauth/callback/kakao/logout`;
 
 export const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${CLIENT_ID}&redirect_uri=${LOGIN_REDIRECT_URI}&response_type=code`;
 export const KAKAO_LOGOUT_URL = `https://kauth.kakao.com/oauth/logout?client_id=${CLIENT_ID}&logout_redirect_uri=${LOGOUT_REDIRECT_URI}`;

--- a/client/src/store/search.ts
+++ b/client/src/store/search.ts
@@ -1,5 +1,5 @@
 import { makeVar } from "@apollo/client";
 import { SEARCH_VALUE } from "../constant/storageKey";
 
-const localSearchValue = localStorage.getItem(SEARCH_VALUE) || "검색어 입력";
+const localSearchValue = localStorage.getItem(SEARCH_VALUE) || "";
 export const searchValueVar = makeVar(localSearchValue);


### PR DESCRIPTION
## 배포환경에서 카카오 로그인 시 호스트 거부 현상 수정
- 클라이언트 BASE URL이 `localhost:3000`으로 된것이 원인
- BASE URL을 환경변수로 설정하였고 `localhost:3000`에서 배포 주소로 변경
- 카카오 디벨로퍼스에서 리다이렉트 URL에 배포주소 추가

## 상품 검색 후 뒤로가기 클릭 시 필터된 데이터가 초기화되는 현상 수정
  - 뒤로가기 클릭 시 쿼리스트링이 초기화가 되버린것이 원인
  - 캐릭터 카테고리 클릭 & 검색 버튼 클릭시 navigator URL에 쿼리스트링 추가